### PR TITLE
Minor CRI fixes

### DIFF
--- a/pkg/kube/container_oci.go
+++ b/pkg/kube/container_oci.go
@@ -172,10 +172,10 @@ func (t *containerTranslator) device(from, to string) (*specs.LinuxDevice, error
 
 	mode := stat.Mode()
 	var devType string
-	if mode&syscall.S_IFBLK == syscall.S_IFBLK {
+	if mode&os.ModeDevice == os.ModeDevice {
 		devType = "b"
 	}
-	if mode&syscall.S_IFCHR == syscall.S_IFCHR {
+	if mode&os.ModeCharDevice == os.ModeCharDevice {
 		devType = "c"
 	}
 	if devType == "" {

--- a/pkg/kube/container_oci.go
+++ b/pkg/kube/container_oci.go
@@ -94,11 +94,13 @@ func (t *containerTranslator) configureMounts() error {
 		Options:     []string{"bind", "ro"},
 	})
 
-	for _, maskedPath := range t.cont.GetLinux().GetSecurityContext().GetMaskedPaths() {
-		t.g.AddLinuxMaskedPaths(maskedPath)
-	}
-	for _, readonlyPath := range t.cont.GetLinux().GetSecurityContext().GetReadonlyPaths() {
-		t.g.AddLinuxReadonlyPaths(readonlyPath)
+	if !t.cont.GetLinux().GetSecurityContext().GetPrivileged() {
+		for _, maskedPath := range t.cont.GetLinux().GetSecurityContext().GetMaskedPaths() {
+			t.g.AddLinuxMaskedPaths(maskedPath)
+		}
+		for _, readonlyPath := range t.cont.GetLinux().GetSecurityContext().GetReadonlyPaths() {
+			t.g.AddLinuxReadonlyPaths(readonlyPath)
+		}
 	}
 
 	if t.cont.GetLinux().GetSecurityContext().GetPrivileged() {

--- a/pkg/server/runtime/runtime.go
+++ b/pkg/server/runtime/runtime.go
@@ -180,7 +180,7 @@ func (s *SingularityRuntime) Version(context.Context, *k8s.VersionRequest) (*k8s
 
 	syVersion, err := exec.Command(s.singularity, "version").Output()
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "could not get Singularity version: %v", err)
 	}
 
 	return &k8s.VersionResponse{


### PR DESCRIPTION
1. Do not set readonly/masked paths if container is privileged (e.g. kube-proxy), see kubernetes/kubernetes#68803
2. Return internal error explicitly if failed to get runtime version
3. Use `os` package instead of `syscall` to determine device type