### PR TITLE
Add auto re-registration for device plugin

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -84,10 +84,10 @@ func main() {
 		criWG.Wait()
 		dpWG.Wait()
 	}
+	defer waitShutdown()
 
 	if err := startCRI(ctx, criWG, config); err != nil {
 		glog.Errorf("Could not start Singularity CRI server: %v", err)
-		waitShutdown()
 		return
 	}
 
@@ -96,7 +96,6 @@ func main() {
 	devicePluginEnabled := err == nil
 	if err != nil && err != errNotSupported {
 		glog.Errorf("Could not start Singularity device plugin: %v", err)
-		waitShutdown()
 		return
 	}
 
@@ -126,13 +125,12 @@ func main() {
 				dpWG = new(sync.WaitGroup)
 				if err := startDevicePlugin(dpCtx, dpWG, config); err != nil {
 					glog.Errorf("Could not restart Singularity device plugin: %v", err)
-					waitShutdown()
 					return
 				}
 			}
 		case <-exitCh:
 			glog.Infof("Received %s signal, shutting down...", <-exitCh)
-			waitShutdown()
+			return
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect
 	github.com/emicklei/go-restful v2.8.0+incompatible // indirect
 	github.com/fatih/color v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 // indirect
 	github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384 // indirect
@@ -46,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.2.2
 	github.com/sylabs/scs-key-client v0.2.0 // indirect
 	github.com/sylabs/sif v1.0.2
-	github.com/sylabs/singularity v3.1.1-0.20190317210357-3bc381b61d3f+incompatible
+	github.com/sylabs/singularity v3.1.1-0.20190318191111-8d93b6061a76+incompatible
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
 	github.com/tchap/go-patricia v2.2.6+incompatible
 	github.com/vishvananda/netlink v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/sylabs/scs-key-client v0.2.0 h1:9nXqgcSotyvUMJEsA4lAFrKtUB14qw3xIKoF6
 github.com/sylabs/scs-key-client v0.2.0/go.mod h1:nMF8PplFD5ZmDz//GHjaip7+MlQ0z4Qe0RCzaT5Xjes=
 github.com/sylabs/sif v1.0.2 h1:yz86Avck4JUVjETWNwncvwkqJXW8GwwSOc5j7JeGA1s=
 github.com/sylabs/sif v1.0.2/go.mod h1:5FM5vX9RuQFr3sDVdQOnb7kKt9vLfRb7igH6GZMy4O4=
-github.com/sylabs/singularity v3.1.1-0.20190317210357-3bc381b61d3f+incompatible h1:MH4eZO8A4zaFpIFU6HgyX39gwW6lHT4R4HKY8TEz29w=
-github.com/sylabs/singularity v3.1.1-0.20190317210357-3bc381b61d3f+incompatible/go.mod h1:os/hL6xzaMVX6cP2GtggnZUmE2Y7jcYR9n2MKTHglRc=
+github.com/sylabs/singularity v3.1.1-0.20190318191111-8d93b6061a76+incompatible h1:qGkDxqSGJVJu16C4X1IG3s7afg/u4LjjNol3j/aoeL8=
+github.com/sylabs/singularity v3.1.1-0.20190318191111-8d93b6061a76+incompatible/go.mod h1:os/hL6xzaMVX6cP2GtggnZUmE2Y7jcYR9n2MKTHglRc=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible h1:JvoDL7JSoIP2HDE8AbDH3zC8QBPxmzYe32HHy5yQ+Ck=

--- a/pkg/fs/watcher.go
+++ b/pkg/fs/watcher.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// OpUnsupported stands for currently unsupported file operation type.
-	OpUnsupported = iota
+	OpUnsupported = Op(iota)
 	// OpRemove is used when watched file was removed.
 	OpRemove
 	// OpCreate is used when watched file was created.
@@ -36,10 +36,13 @@ type Watcher struct {
 	*fsnotify.Watcher
 }
 
+// Op is a separate type for watch file events.
+type Op int
+
 // WatchEvent is a single event that happens during filesystem watch.
 type WatchEvent struct {
 	Path string
-	Op   int
+	Op   Op
 }
 
 // NewWatcher creates new Watcher that will be watching passed files or directories
@@ -72,7 +75,7 @@ func (w *Watcher) Watch(ctx context.Context) <-chan WatchEvent {
 		for {
 			select {
 			case event := <-w.Events:
-				var op int
+				var op Op
 				if event.Op&fsnotify.Create == fsnotify.Create {
 					op = OpCreate
 				}

--- a/pkg/fs/watcher.go
+++ b/pkg/fs/watcher.go
@@ -68,6 +68,7 @@ func NewWatcher(files ...string) (*Watcher, error) {
 func (w *Watcher) Watch(ctx context.Context) <-chan WatchEvent {
 	events := make(chan WatchEvent)
 	go func() {
+		defer close(events)
 		for {
 			select {
 			case event := <-w.Events:

--- a/pkg/fs/watcher.go
+++ b/pkg/fs/watcher.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2018-2019 Sylabs, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	// OpUnsupported stands for currently unsupported file operation type.
+	OpUnsupported = iota
+	// OpRemove is used when watched file was removed.
+	OpRemove
+	// OpCreate is used when watched file was created.
+	OpCreate
+)
+
+// Watcher is a filesystem watcher that can be used
+// to watch filesystem changes.
+type Watcher struct {
+	*fsnotify.Watcher
+}
+
+// WatchEvent is a single event that happens during filesystem watch.
+type WatchEvent struct {
+	Path string
+	Op   int
+}
+
+// NewWatcher creates new Watcher that will be watching passed files or directories
+// that already exist. Currently only create and remove operations are supported.
+// NOTE: when watching a single file no new event will be triggered after it's removal.
+func NewWatcher(files ...string) (*Watcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("could not create file watcher: %v", err)
+	}
+
+	for _, f := range files {
+		err = watcher.Add(f)
+		if err != nil {
+			watcher.Close()
+			return nil, fmt.Errorf("could not add %s to file watcher: %v", f, err)
+		}
+	}
+
+	return &Watcher{Watcher: watcher}, nil
+}
+
+// Watch starts filesystem watching, all occurred events will be sent
+// to returned channel. Returned channel in unbuffered, so make sure to read from
+// it. Watcher will be cancelled as soon as context is done.
+func (w *Watcher) Watch(ctx context.Context) <-chan WatchEvent {
+	events := make(chan WatchEvent)
+	go func() {
+		for {
+			select {
+			case event := <-w.Events:
+				var op int
+				if event.Op&fsnotify.Create == fsnotify.Create {
+					op = OpCreate
+				}
+				if event.Op&fsnotify.Remove == fsnotify.Remove {
+					op = OpRemove
+				}
+				if op == OpUnsupported {
+					continue
+				}
+				events <- WatchEvent{
+					Path: event.Name,
+					Op:   op,
+				}
+			case err := <-w.Errors:
+				// we skip errors for now
+				_ = err
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return events
+}

--- a/pkg/fs/watcher_test.go
+++ b/pkg/fs/watcher_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2018-2019 Sylabs, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatcher(t *testing.T) {
+	file1 := filepath.Join(os.TempDir(), "test-watcher-1")
+	file2 := filepath.Join(os.TempDir(), "test-watcher-2")
+	file3 := filepath.Join(os.TempDir(), "test-watcher-3")
+
+	f1, err := os.Create(file1)
+	require.NoError(t, err, "could not create test file")
+	require.NoError(t, f1.Close())
+
+	f2, err := os.Create(file2)
+	require.NoError(t, err, "could not create test file")
+	require.NoError(t, f2.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	watcher, err := NewWatcher(os.TempDir())
+	require.NoError(t, err, "could not create watcher", err)
+	defer func() {
+		cancel()
+		require.NoError(t, watcher.Close(), "could not close watcher")
+	}()
+
+	upd := watcher.Watch(ctx)
+
+	require.NoError(t, os.Remove(file1), "could not remove test file")
+	require.Equal(t, WatchEvent{
+		Path: file1,
+		Op:   OpRemove,
+	}, <-upd, "unexpected update")
+
+	require.NoError(t, os.Remove(file2), "could not remove test file")
+	require.Equal(t, WatchEvent{
+		Path: file2,
+		Op:   OpRemove,
+	}, <-upd, "unexpected update")
+
+	f2, err = os.Create(file2)
+	require.NoError(t, err, "could not create test file")
+	require.NoError(t, f2.Close())
+	require.Equal(t, WatchEvent{
+		Path: file2,
+		Op:   OpCreate,
+	}, <-upd, "unexpected update")
+
+	f3, err := os.Create(file3)
+	require.NoError(t, err, "could not create test file")
+	require.NoError(t, f3.Close())
+	require.Equal(t, WatchEvent{
+		Path: file3,
+		Op:   OpCreate,
+	}, <-upd, "unexpected update")
+
+	file2New := file2 + "_new"
+	require.NoError(t, os.Rename(file2, file2New), "could not rename test file")
+	select {
+	case <-upd:
+		t.Fatal("Unexpected event after rename")
+	default:
+	}
+	require.NoError(t, os.Remove(file2New), "could not remove renamed file")
+	require.NoError(t, os.Remove(file3), "could not remove test file")
+}

--- a/pkg/server/device/device.go
+++ b/pkg/server/device/device.go
@@ -153,9 +153,7 @@ func (dp *SingularityDevicePlugin) Shutdown() error {
 
 // GetDevicePluginOptions returns options to be communicated with Device Manager.
 func (*SingularityDevicePlugin) GetDevicePluginOptions(context.Context, *k8sDP.Empty) (*k8sDP.DevicePluginOptions, error) {
-	return &k8sDP.DevicePluginOptions{
-		PreStartRequired: true,
-	}, nil
+	return &k8sDP.DevicePluginOptions{}, nil
 }
 
 // ListAndWatch returns a stream of List of Devices. Whenever a Device state changes

--- a/pkg/server/device/register.go
+++ b/pkg/server/device/register.go
@@ -58,12 +58,12 @@ const resourceName = "nvidia.com/gpu"
 // RegisterInKubelet registers Singularity device plugin that is
 // listening on socket in kubelet.
 func RegisterInKubelet(socket string) error {
-	for attempt := 1; attempt < 10; attempt += 2 {
+	for attempt := 1; attempt < 5; attempt++ {
 		err := register(socket)
 		if err != nil {
 			glog.Errorf("Registration failed: %v", err)
-			timeout := time.Second * time.Duration(attempt)
-			glog.Errorf("Retrying in %d seconds", attempt)
+			timeout := time.Second * time.Duration(attempt*2)
+			glog.Errorf("Retrying in %d seconds", timeout.Seconds())
 			time.Sleep(timeout)
 			continue
 		}

--- a/pkg/server/device/register.go
+++ b/pkg/server/device/register.go
@@ -46,7 +46,9 @@ package device
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc"
 	k8sDP "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1beta1"
 )
@@ -56,6 +58,21 @@ const resourceName = "nvidia.com/gpu"
 // RegisterInKubelet registers Singularity device plugin that is
 // listening on socket in kubelet.
 func RegisterInKubelet(socket string) error {
+	for attempt := 1; attempt < 10; attempt += 2 {
+		err := register(socket)
+		if err != nil {
+			glog.Errorf("Registration failed: %v", err)
+			timeout := time.Second * time.Duration(attempt)
+			glog.Errorf("Retrying in %d seconds", timeout)
+			time.Sleep(timeout)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("failed to register in kubelet")
+}
+
+func register(socket string) error {
 	conn, err := grpc.Dial("unix://"+k8sDP.KubeletSocket, grpc.WithInsecure())
 	if err != nil {
 		return fmt.Errorf("could not dial kubelet: %v", err)

--- a/pkg/server/device/register.go
+++ b/pkg/server/device/register.go
@@ -63,7 +63,7 @@ func RegisterInKubelet(socket string) error {
 		if err != nil {
 			glog.Errorf("Registration failed: %v", err)
 			timeout := time.Second * time.Duration(attempt*2)
-			glog.Errorf("Retrying in %d seconds", timeout.Seconds())
+			glog.Errorf("Retrying in %f seconds", timeout.Seconds())
 			time.Sleep(timeout)
 			continue
 		}

--- a/pkg/server/device/register.go
+++ b/pkg/server/device/register.go
@@ -63,7 +63,7 @@ func RegisterInKubelet(socket string) error {
 		if err != nil {
 			glog.Errorf("Registration failed: %v", err)
 			timeout := time.Second * time.Duration(attempt)
-			glog.Errorf("Retrying in %d seconds", timeout)
+			glog.Errorf("Retrying in %d seconds", attempt)
 			time.Sleep(timeout)
 			continue
 		}


### PR DESCRIPTION
According to [device plugin docs](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) we need to track kubelet restarts and then re-register our device plugin once again. To achieve this file watcher is used to track kubelet socket recreation. Also registration timeouts added in order to give kubelet some time to start accepting requests in case it has just booted.

Closes #208 