### PR TITLE
Correctly check seccomp headers in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CRI_CONFIG_INSTALL := /usr/local/etc/sycri/sycri.yaml
 
 all: $(SY_CRI) $(FAKE_SH)
 
-$(SY_CRI): SECCOMP := "$(shell echo '#include <seccomp.h>\nint main() { }' | gcc -x c -o /dev/null -lseccomp - >/dev/null 2>&1; echo $$?)"
+$(SY_CRI): SECCOMP := "$(shell printf "#include <seccomp.h>\nint main() { seccomp_syscall_resolve_name(\"read\"); }" | gcc -x c -o /dev/null - -lseccomp >/dev/null 2>&1; echo $$?)"
 $(SY_CRI): export GO111MODULE=on
 $(SY_CRI):
 	@echo " GO" $@


### PR DESCRIPTION
With `echo` "\n" appeared in test source and may have resulted in false negatives.
Printf approach is the same we use in Singularity during `./mconfig`, tested on Ubuntu 18.04 and CentOS 7.

Should fix #225 