### PR TITLE
Use x/sys package insted of syscall

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -108,7 +108,6 @@ func main() {
 		watcher, err := fs.NewWatcher(k8sDP.DevicePluginPath)
 		if err != nil {
 			glog.Errorf("Could not create kubelet file watcher: %v", err)
-			waitShutdown()
 			return
 		}
 		defer watcher.Close()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -94,6 +94,7 @@ func main() {
 	}
 
 	dpCtx, dpCancel := context.WithCancel(ctx)
+	defer dpCancel()
 	err = startDevicePlugin(dpCtx, dpWG, config)
 	devicePluginEnabled := err == nil
 	if err != nil && err != errGPUNotSupported {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -94,7 +94,6 @@ func main() {
 	}
 
 	dpCtx, dpCancel := context.WithCancel(ctx)
-	defer dpCancel()
 	err = startDevicePlugin(dpCtx, dpWG, config)
 	devicePluginEnabled := err == nil
 	if err != nil && err != errGPUNotSupported {
@@ -123,10 +122,12 @@ func main() {
 				dpCancel()
 				dpWG.Wait()
 
+				//nolint:vet
 				dpCtx, dpCancel = context.WithCancel(ctx)
 				dpWG = new(sync.WaitGroup)
 				if err := startDevicePlugin(dpCtx, dpWG, config); err != nil {
 					glog.Errorf("Could not restart Singularity device plugin: %v", err)
+					//nolint:vet
 					return
 				}
 			}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
 
 	"github.com/golang/glog"
 	"github.com/sylabs/singularity-cri/pkg/fs"
@@ -32,6 +31,7 @@ import (
 	"github.com/sylabs/singularity-cri/pkg/server/image"
 	"github.com/sylabs/singularity-cri/pkg/server/runtime"
 	useragent "github.com/sylabs/singularity/pkg/util/user-agent"
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
 	k8s "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
@@ -73,10 +73,10 @@ func main() {
 
 	// Initialize user agent strings
 	useragent.InitValue("singularity", "3.1.0")
-	syscall.Umask(0)
+	unix.Umask(0)
 
 	exitCh := make(chan os.Signal, 1)
-	signal.Notify(exitCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(exitCh, unix.SIGINT, unix.SIGTERM, unix.SIGQUIT)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	criWG := new(sync.WaitGroup)

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180816142147-da425ebb7609 // indirect
 	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect
+	golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54 // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/genproto v0.0.0-20181109154231-b5d43981345b // indirect
 	google.golang.org/grpc v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v0.0.0-20180816142147-da425ebb7609 // indirect
 	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect
-	golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54 // indirect
+	golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/genproto v0.0.0-20181109154231-b5d43981345b // indirect
 	google.golang.org/grpc v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54 h1:xe1/2UUJRmA9iDglQSlkx8c5n3twv58+K0mPpC2zmhA=
+golang.org/x/sys v0.0.0-20190321052220-f7bb7a8bee54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=

--- a/pkg/singularity/runtime/client_oci.go
+++ b/pkg/singularity/runtime/client_oci.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/golang/glog"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/pkg/ociruntime"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -157,8 +157,8 @@ func (c *CLIClient) ExecSync(ctx context.Context, id string, args ...string) (*E
 	var exitCode int32
 	exitErr, ok := err.(*exec.ExitError)
 	if ok {
-		var waitStatus syscall.WaitStatus
-		waitStatus, ok = exitErr.Sys().(syscall.WaitStatus)
+		var waitStatus unix.WaitStatus
+		waitStatus, ok = exitErr.Sys().(unix.WaitStatus)
 		if ok {
 			exitCode = int32(waitStatus.ExitStatus())
 		}

--- a/pkg/singularity/runtime/client_oci.go
+++ b/pkg/singularity/runtime/client_oci.go
@@ -23,11 +23,11 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/golang/glog"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sylabs/singularity/pkg/ociruntime"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -157,8 +157,9 @@ func (c *CLIClient) ExecSync(ctx context.Context, id string, args ...string) (*E
 	var exitCode int32
 	exitErr, ok := err.(*exec.ExitError)
 	if ok {
-		var waitStatus unix.WaitStatus
-		waitStatus, ok = exitErr.Sys().(unix.WaitStatus)
+		// TODO use unix package here
+		var waitStatus syscall.WaitStatus
+		waitStatus, ok = exitErr.Sys().(syscall.WaitStatus)
 		if ok {
 			exitCode = int32(waitStatus.ExitStatus())
 		}


### PR DESCRIPTION
According to [go docs](https://golang.org/src/syscall/syscall.go) `syscall` package is deprecated and we should use `x/sys` instead.

Closes #222 