### PR TITLE
Fix incorrect fs watcher test

### DIFF
--- a/pkg/fs/watcher_test.go
+++ b/pkg/fs/watcher_test.go
@@ -76,11 +76,11 @@ func TestWatcher(t *testing.T) {
 
 	file2New := file2 + "_new"
 	require.NoError(t, os.Rename(file2, file2New), "could not rename test file")
-	select {
-	case <-upd:
-		t.Fatal("Unexpected event after rename")
-	default:
-	}
+	require.Equal(t, WatchEvent{
+		Path: file2New,
+		Op:   OpCreate,
+	}, <-upd, "unexpected update")
+
 	require.NoError(t, os.Remove(file2New), "could not remove renamed file")
 	require.NoError(t, os.Remove(file3), "could not remove test file")
 }


### PR DESCRIPTION
I didn't take into account that:
1. watcher may need some time to trigger the event
2. file renaming will trigger both RENAME and CREATE events