### PR TITLE
Add OCI config marshalling

### DIFF
--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -15,6 +15,7 @@
 package image
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -44,16 +45,16 @@ func TestPullImage(t *testing.T) {
 				digests: nil,
 			},
 			expectImage: &Info{
-				id:     "",
-				sha256: "",
-				size:   745472,
-				path:   "",
-				ref: &Reference{
+				ID:     "",
+				Sha256: "",
+				Size:   745472,
+				Path:   "",
+				Ref: &Reference{
 					uri:     singularity.DockerDomain,
 					tags:    []string{"gcr.io/cri-tools/test-image-latest"},
 					digests: nil,
 				},
-				ociConfig: &specs.ImageConfig{
+				OciConfig: &specs.ImageConfig{
 					Env: []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 					Cmd: []string{"sh"},
 				},
@@ -68,11 +69,11 @@ func TestPullImage(t *testing.T) {
 				digests: []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
 			},
 			expectImage: &Info{
-				id:     "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
-				sha256: "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
-				size:   5521408,
-				path:   filepath.Join(os.TempDir(), "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"),
-				ref: &Reference{
+				ID:     "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
+				Sha256: "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0",
+				Size:   5521408,
+				Path:   filepath.Join(os.TempDir(), "d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"),
+				Ref: &Reference{
 					uri:     singularity.LibraryDomain,
 					tags:    nil,
 					digests: []string{"cloud.sylabs.io/sashayakovtseva/test/image-server:sha256.d50278eebfe4ca5655cc28503983f7c947914a34fbbb805481657d39e98f33f0"},
@@ -90,9 +91,9 @@ func TestPullImage(t *testing.T) {
 				require.NoError(t, image.Remove(), "could not remove image")
 			}
 			if tc.ref.uri == singularity.DockerDomain {
-				image.id = ""
-				image.sha256 = ""
-				image.path = ""
+				image.ID = ""
+				image.Sha256 = ""
+				image.Path = ""
 			}
 			require.Equal(t, tc.expectImage, image, "image mismatch")
 		})
@@ -155,7 +156,7 @@ func TestInfo_Remove(t *testing.T) {
 			defer f.Close()
 
 			image := &Info{
-				path: f.Name(),
+				Path: f.Name(),
 			}
 			for _, b := range tc.borrow {
 				image.Borrow(b)
@@ -181,8 +182,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "no filter",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{"gcr.io/cri-tools/test-image-tags:1", "gcr.io/cri-tools/test-image-tags:2"},
 					digests: []string{},
 				},
@@ -193,8 +194,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "id match",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{"gcr.io/cri-tools/test-image-tags:1", "gcr.io/cri-tools/test-image-tags:2"},
 					digests: []string{},
 				},
@@ -209,8 +210,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "tag match",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{"gcr.io/cri-tools/test-image-tags:1", "gcr.io/cri-tools/test-image-tags:2"},
 					digests: []string{},
 				},
@@ -225,8 +226,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "digest match",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{},
 					digests: []string{"gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"},
 				},
@@ -241,8 +242,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "empty filter",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{},
 					digests: []string{"gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"},
 				},
@@ -257,8 +258,8 @@ func TestInfo_Matches(t *testing.T) {
 		{
 			name: "no match",
 			img: &Info{
-				id: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
-				ref: &Reference{
+				ID: "7b0178cb4bac7227f83a56d62d3fdf9900645b6d53578aaad25a7df61ae15b39",
+				Ref: &Reference{
 					tags:    []string{},
 					digests: []string{"gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343"},
 				},
@@ -280,43 +281,158 @@ func TestInfo_Matches(t *testing.T) {
 }
 
 func TestInfo_UnmarshalJSON(t *testing.T) {
-	input := `
-{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-"size":741376,
-"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-"ref":{"uri":"docker.io","tags":["busybox:1.28"],"digests":null}}`
-
-	info := new(Info)
-	err := info.UnmarshalJSON([]byte(input))
-	require.NoError(t, err, "could not unmarshal image")
-	require.Equal(t, &Info{
-		id:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		size:   741376,
-		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		ref: &Reference{
-			uri:  singularity.DockerDomain,
-			tags: []string{"busybox:1.28"},
+	tt := []struct {
+		name   string
+		input  string
+		expect *Info
+	}{
+		{
+			name: "all filled",
+			input: `
+				{
+					"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"size":741376,
+					"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"ref":{
+						"uri":"docker.io",
+						"tags":["busybox:1.28"],
+						"digests":null
+					},
+					"ociConfig":{
+						"User":"sasha",
+						"WorkingDir":"/opt/go",
+						"Cmd":["./my-server"]
+					}
+				}`,
+			expect: &Info{
+				ID:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Size:   741376,
+				Path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Ref: &Reference{
+					uri:  singularity.DockerDomain,
+					tags: []string{"busybox:1.28"},
+				},
+				OciConfig: &specs.ImageConfig{
+					User:       "sasha",
+					Cmd:        []string{"./my-server"},
+					WorkingDir: "/opt/go",
+				},
+			},
 		},
-	}, info)
-}
-
-func TestInfo_MarshalJSON(t *testing.T) {
-	expect := []byte(`{"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","size":741376,"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0","ref":{"uri":"docker.io","tags":["busybox:1.28"],"digests":null}}`)
-
-	info := &Info{
-		id:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		size:   741376,
-		path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
-		ref: &Reference{
-			uri:  singularity.DockerDomain,
-			tags: []string{"busybox:1.28"},
+		{
+			name: "no oci config",
+			input: `
+				{
+					"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"size":741376,
+					"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"ref":{
+						"uri":"docker.io",
+						"tags":["busybox:1.28"],
+						"digests":null
+					}
+				}`,
+			expect: &Info{
+				ID:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Size:   741376,
+				Path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Ref: &Reference{
+					uri:  singularity.DockerDomain,
+					tags: []string{"busybox:1.28"},
+				},
+			},
 		},
 	}
 
-	res, err := info.MarshalJSON()
-	require.NoError(t, err, "could not marshal image")
-	require.Equal(t, expect, res)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var info *Info
+			err := json.Unmarshal([]byte(tc.input), &info)
+			require.NoError(t, err, "could not unmarshal image")
+			require.Equal(t, tc.expect, info)
+		})
+	}
+}
+
+func TestInfo_MarshalJSON(t *testing.T) {
+	tt := []struct {
+		name   string
+		input  *Info
+		expect string
+	}{
+		{
+			name: "all filled",
+			input: &Info{
+				ID:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Size:   741376,
+				Path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Ref: &Reference{
+					uri:  singularity.DockerDomain,
+					tags: []string{"busybox:1.28"},
+				},
+				OciConfig: &specs.ImageConfig{
+					User:       "sasha",
+					Cmd:        []string{"./my-server"},
+					WorkingDir: "/opt/go",
+				},
+				usedBy: []string{"should-not-marshal"},
+			},
+			expect: `
+				{
+					"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"size":741376,
+					"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"ref":{
+						"uri":"docker.io",
+						"tags":["busybox:1.28"],
+						"digests":null
+					},
+					"ociConfig":{
+						"User":"sasha",
+						"WorkingDir":"/opt/go",
+						"Cmd":["./my-server"]
+					}
+				}`,
+		},
+		{
+			name: "no oci config",
+			input: &Info{
+				ID:     "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Sha256: "0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Size:   741376,
+				Path:   "/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+				Ref: &Reference{
+					uri:  singularity.DockerDomain,
+					tags: []string{"busybox:1.28"},
+				},
+				usedBy: []string{"should-not-marshal"},
+			},
+			expect: `
+				{
+					"id":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"sha256":"0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"size":741376,
+					"path":"/var/lib/singularity/0d408f32cc56b16509f30ae3dfa56ffb01269b2100036991d49af645a7b717a0",
+					"ref":{
+						"uri":"docker.io",
+						"tags":["busybox:1.28"],
+						"digests":null
+					}
+				}`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := json.Marshal(tc.input)
+			require.NoError(t, err, "could not marshal image")
+			require.JSONEq(t, tc.expect, string(res))
+		})
+	}
 }

--- a/pkg/index/image.go
+++ b/pkg/index/image.go
@@ -56,7 +56,7 @@ func (i *ImageIndex) Find(id string) (*image.Info, error) {
 // Add adds the given image info to the index.
 // If image with the same ID already exists it updates old image info appropriately.
 func (i *ImageIndex) Add(image *image.Info) error {
-	oldImage, err := i.Find(image.ID())
+	oldImage, err := i.Find(image.ID)
 	if err != nil && err != ErrNotFound {
 		return fmt.Errorf("could not find old image: %v", err)
 	}
@@ -72,13 +72,13 @@ func (i *ImageIndex) Remove(id string) error {
 	if err != nil {
 		return err
 	}
-	err = i.indx.Delete(imgInfo.ID())
+	err = i.indx.Delete(imgInfo.ID)
 	if err != nil {
 		return fmt.Errorf("could not remove image: %v", err)
 	}
 
-	i.removeRefs(imgInfo.Ref().Tags()...)
-	i.removeRefs(imgInfo.Ref().Digests()...)
+	i.removeRefs(imgInfo.Ref.Tags()...)
+	i.removeRefs(imgInfo.Ref.Digests()...)
 	return nil
 }
 
@@ -106,61 +106,61 @@ func (i *ImageIndex) add(image *image.Info) error {
 	if err := i.removeOverlapRefs(image); err != nil {
 		return nil
 	}
-	err := i.indx.Add(image.ID(), image)
+	err := i.indx.Add(image.ID, image)
 	if err != nil {
 		return fmt.Errorf("could not add image: %v", err)
 	}
-	for _, tag := range image.Ref().Tags() {
-		i.setRef(tag, image.ID())
+	for _, tag := range image.Ref.Tags() {
+		i.setRef(tag, image.ID)
 	}
-	for _, digest := range image.Ref().Digests() {
-		i.setRef(digest, image.ID())
+	for _, digest := range image.Ref.Digests() {
+		i.setRef(digest, image.ID)
 	}
 	return nil
 }
 
 func (i *ImageIndex) merge(oldImage, image *image.Info) error {
-	oldImage.Ref().AddTags(image.Ref().Tags())
-	oldImage.Ref().AddDigests(image.Ref().Digests())
+	oldImage.Ref.AddTags(image.Ref.Tags())
+	oldImage.Ref.AddDigests(image.Ref.Digests())
 
-	for _, tag := range image.Ref().Tags() {
+	for _, tag := range image.Ref.Tags() {
 		oldID := i.readRef(tag)
-		i.setRef(tag, image.ID())
-		if oldID != "" && oldID != image.ID() {
-			oldInfo, _ := i.Find(image.ID())
-			oldInfo.Ref().RemoveTag(tag)
+		i.setRef(tag, image.ID)
+		if oldID != "" && oldID != image.ID {
+			oldInfo, _ := i.Find(image.ID)
+			oldInfo.Ref.RemoveTag(tag)
 		}
 	}
-	for _, digest := range image.Ref().Digests() {
+	for _, digest := range image.Ref.Digests() {
 		oldID := i.readRef(digest)
-		i.setRef(digest, image.ID())
-		if oldID != "" && oldID == image.ID() {
-			oldInfo, _ := i.Find(image.ID())
-			oldInfo.Ref().RemoveDigest(digest)
+		i.setRef(digest, image.ID)
+		if oldID != "" && oldID == image.ID {
+			oldInfo, _ := i.Find(image.ID)
+			oldInfo.Ref.RemoveDigest(digest)
 		}
 	}
 	return nil
 }
 
 func (i *ImageIndex) removeOverlapRefs(image *image.Info) error {
-	for _, tag := range image.Ref().Tags() {
+	for _, tag := range image.Ref.Tags() {
 		oldID := i.readRef(tag)
 		if oldID != "" {
 			oldImg, err := i.find(oldID)
 			if err != nil {
 				return err
 			}
-			oldImg.Ref().RemoveTag(tag)
+			oldImg.Ref.RemoveTag(tag)
 		}
 	}
-	for _, digest := range image.Ref().Digests() {
+	for _, digest := range image.Ref.Digests() {
 		oldID := i.readRef(digest)
 		if oldID != "" {
 			oldImg, err := i.find(oldID)
 			if err != nil {
 				return err
 			}
-			oldImg.Ref().RemoveDigest(digest)
+			oldImg.Ref.RemoveDigest(digest)
 		}
 	}
 	return nil

--- a/pkg/index/image_test.go
+++ b/pkg/index/image_test.go
@@ -30,31 +30,31 @@ func SmokeTestImageIndex(t *testing.T) {
 	indx := NewImageIndex()
 
 	img1 := new(image.Info)
-	img1.SetID("busybox")
+	img1.ID = "busybox"
 	ref, err := image.ParseRef("library://library/default/busybox:1.29")
 	require.NoError(t, err, "could not parse busybox ref")
-	img1.SetRef(ref)
+	img1.Ref = ref
 
 	img2 := new(image.Info)
-	img2.SetID("nginx")
+	img2.ID = "nginx"
 	ref, err = image.ParseRef("nginx@sha256:31b8e90a349d1fce7621f5a5a08e4fc519b634f7d3feb09d53fac9b12aa4d991")
 	require.NoError(t, err, "could not parse nginx ref")
-	img2.SetRef(ref)
+	img2.Ref = ref
 
 	img3 := new(image.Info)
-	img3.SetID("alpine")
+	img3.ID = "alpine"
 	ref, err = image.ParseRef("library://library/default/alpine:3.8")
 	require.NoError(t, err, "could not parse alpine ref")
-	img3.SetRef(ref)
+	img3.Ref = ref
 
 	img4 := new(image.Info)
-	img4.SetID("alpine2")
+	img4.ID = "alpine2"
 	ref, err = image.ParseRef("library://library/default/alpine")
 	require.NoError(t, err, "could not parse alpine ref")
-	img4.SetRef(ref)
+	img4.Ref = ref
 
 	t.Run("search empty index", func(t *testing.T) {
-		found, err := indx.Find(img1.ID())
+		found, err := indx.Find(img1.ID)
 		require.Equal(t, ErrNotFound, err, "empty index didn't return ErrImageNotFound")
 		require.Nil(t, found, "empty index returned image")
 	})
@@ -69,23 +69,23 @@ func SmokeTestImageIndex(t *testing.T) {
 	})
 
 	t.Run("search non-empty index", func(t *testing.T) {
-		found, err := indx.Find(img1.ID())
+		found, err := indx.Find(img1.ID)
 		require.NoError(t, err, "index returned unexpected error")
-		require.Equal(t, found.ID(), img1.ID(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Tags(), img1.Ref().Tags(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Digests(), img1.Ref().Digests(), "index returned wrong image")
+		require.Equal(t, found.ID, img1.ID, "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Tags(), img1.Ref.Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Digests(), img1.Ref.Digests(), "index returned wrong image")
 
-		found, err = indx.Find(img2.ID())
+		found, err = indx.Find(img2.ID)
 		require.NoError(t, err, "index returned unexpected error")
-		require.Equal(t, found.ID(), img2.ID(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Tags(), img2.Ref().Tags(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Digests(), img2.Ref().Digests(), "index returned wrong image")
+		require.Equal(t, found.ID, img2.ID, "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Tags(), img2.Ref.Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Digests(), img2.Ref.Digests(), "index returned wrong image")
 
-		found, err = indx.Find(img3.ID())
+		found, err = indx.Find(img3.ID)
 		require.NoError(t, err, "index returned unexpected error")
-		require.Equal(t, found.ID(), img3.ID(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Tags(), img3.Ref().Tags(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Digests(), img3.Ref().Digests(), "index returned wrong image")
+		require.Equal(t, found.ID, img3.ID, "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Tags(), img3.Ref.Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Digests(), img3.Ref.Digests(), "index returned wrong image")
 
 		found, err = indx.Find("nonExistentID")
 		require.Equal(t, ErrNotFound, err, "empty index didn't return ErrImageNotFound")
@@ -93,10 +93,10 @@ func SmokeTestImageIndex(t *testing.T) {
 	})
 
 	t.Run("remove from index", func(t *testing.T) {
-		err := indx.Remove(img2.Ref().Digests()[0])
+		err := indx.Remove(img2.Ref.Digests()[0])
 		require.NoError(t, err, "could not remove image from index")
 
-		found, err := indx.Find(img2.ID())
+		found, err := indx.Find(img2.ID)
 		require.Equal(t, ErrNotFound, err, "empty index didn't return ErrImageNotFound")
 		require.Nil(t, found, "index returned unexpected image")
 	})
@@ -105,18 +105,18 @@ func SmokeTestImageIndex(t *testing.T) {
 		err := indx.Add(img4)
 		require.NoError(t, err)
 
-		found, err := indx.Find(img3.ID())
+		found, err := indx.Find(img3.ID)
 		require.Errorf(t, err, "index didn't error on ambiguous image id")
 		require.Nil(t, found, "index returned wrong image")
 
-		err = indx.Remove(img4.Ref().Tags()[0])
+		err = indx.Remove(img4.Ref.Tags()[0])
 		require.NoError(t, err, "could not remove ambiguous image from index")
 
-		found, err = indx.Find(img3.ID())
+		found, err = indx.Find(img3.ID)
 		require.NoError(t, err, "index returned unexpected error")
-		require.Equal(t, found.ID(), img3.ID(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Tags(), img3.Ref().Tags(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Digests(), img3.Ref().Digests(), "index returned wrong image")
+		require.Equal(t, found.ID, img3.ID, "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Tags(), img3.Ref.Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Digests(), img3.Ref.Digests(), "index returned wrong image")
 	})
 
 }
@@ -125,24 +125,24 @@ func AdvancedTestImageIndex(t *testing.T) {
 	indx := NewImageIndex()
 
 	img1 := new(image.Info)
-	img1.SetID("busybox")
+	img1.ID = "busybox"
 	ref, err := image.ParseRef("library://library/default/busybox:1.29")
 	require.NoError(t, err, "could not parse busybox ref")
-	img1.SetRef(ref)
+	img1.Ref = ref
 
 	img2 := new(image.Info)
-	img2.SetID("busybox")
+	img2.ID = "busybox"
 	ref, err = image.ParseRef("library://library/default/busybox:1.29")
 	require.NoError(t, err, "could not parse busybox ref")
 	ref.AddTags([]string{"library://library/default/busybox:latest"})
 	ref.AddDigests([]string{"library://library/default/busybox:sha256.165768770ca428e9e6d8290d5672652773edf1f80d442252a0ec737ed2cc312c"})
-	img2.SetRef(ref)
+	img2.Ref = ref
 
 	img3 := new(image.Info)
-	img3.SetID("busyboxNew")
+	img3.ID = "busyboxNew"
 	ref, err = image.ParseRef("library://library/default/busybox:latest")
 	require.NoError(t, err, "could not parse busybox ref")
-	img3.SetRef(ref)
+	img3.Ref = ref
 
 	err = indx.Add(img1)
 	require.NoError(t, err)
@@ -151,11 +151,11 @@ func AdvancedTestImageIndex(t *testing.T) {
 		err := indx.Add(img2)
 		require.NoError(t, err)
 
-		found, err := indx.Find(img1.ID())
+		found, err := indx.Find(img1.ID)
 		require.NoError(t, err, "index returned unexpected error")
-		require.Equal(t, found.ID(), img2.ID(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Tags(), img2.Ref().Tags(), "index returned wrong image")
-		require.ElementsMatch(t, found.Ref().Digests(), img2.Ref().Digests(), "index returned wrong image")
+		require.Equal(t, found.ID, img2.ID, "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Tags(), img2.Ref.Tags(), "index returned wrong image")
+		require.ElementsMatch(t, found.Ref.Digests(), img2.Ref.Digests(), "index returned wrong image")
 	})
 
 	t.Run("add overlapping image", func(t *testing.T) {
@@ -166,13 +166,13 @@ func AdvancedTestImageIndex(t *testing.T) {
 		indx.Iterate(func(image *image.Info) {
 			count++
 
-			if image.ID() == img2.ID() {
-				require.ElementsMatch(t, image.Ref().Tags(), img1.Ref().Tags(), "index returned wrong old image tags")
-				require.ElementsMatch(t, image.Ref().Digests(), img2.Ref().Digests(), "index returned wrong old image digests")
+			if image.ID == img2.ID {
+				require.ElementsMatch(t, image.Ref.Tags(), img1.Ref.Tags(), "index returned wrong old image tags")
+				require.ElementsMatch(t, image.Ref.Digests(), img2.Ref.Digests(), "index returned wrong old image digests")
 			}
-			if image.ID() == img3.ID() {
-				require.ElementsMatch(t, image.Ref().Tags(), img3.Ref().Tags(), "index returned wrong new image tags")
-				require.ElementsMatch(t, image.Ref().Digests(), img3.Ref().Digests(), "index returned wrong new image digests")
+			if image.ID == img3.ID {
+				require.ElementsMatch(t, image.Ref.Tags(), img3.Ref.Tags(), "index returned wrong new image tags")
+				require.ElementsMatch(t, image.Ref.Digests(), img3.Ref.Digests(), "index returned wrong new image digests")
 			}
 		})
 		require.Equal(t, 2, count)

--- a/pkg/kube/container.go
+++ b/pkg/kube/container.go
@@ -161,7 +161,7 @@ func (c *Container) LogPath() string {
 
 // ImageID returns id of the container base image.
 func (c *Container) ImageID() string {
-	return c.imgInfo.ID()
+	return c.imgInfo.ID
 }
 
 // Stdin returns write end of container's stdin, if any. If container

--- a/pkg/kube/container_files.go
+++ b/pkg/kube/container_files.go
@@ -75,7 +75,7 @@ func (c *Container) addLogDirectory() error {
 
 func (c *Container) addOCIBundle() error {
 	glog.V(8).Infof("Creating SIF bundle at %s", c.bundlePath())
-	d, err := ocibundle.FromSif(c.imgInfo.Path(), c.bundlePath(), true)
+	d, err := ocibundle.FromSif(c.imgInfo.Path, c.bundlePath(), true)
 	if err != nil {
 		return fmt.Errorf("could not create SIF bundle driver: %v", err)
 	}

--- a/pkg/kube/container_oci.go
+++ b/pkg/kube/container_oci.go
@@ -243,10 +243,10 @@ func (t *containerTranslator) configureProcess() error {
 		execScript = "/.singularity.d/actions/exec"
 		runScript  = "/.singularity.d/actions/run"
 	)
-	if t.cont.imgInfo.OciConfig() != nil {
+	if t.cont.imgInfo.OciConfig != nil {
 		// add image envs first and allow container config to override them
 		// assuming VARNAME=VARVALUE format
-		for _, env := range t.cont.imgInfo.OciConfig().Env {
+		for _, env := range t.cont.imgInfo.OciConfig.Env {
 			parts := strings.Split(env, "=")
 			t.g.AddProcessEnv(parts[0], parts[1])
 		}
@@ -255,9 +255,9 @@ func (t *containerTranslator) configureProcess() error {
 		t.g.AddProcessEnv(env.GetKey(), env.GetValue())
 	}
 	cwd := t.cont.GetWorkingDir()
-	if cwd == "" && t.cont.imgInfo.OciConfig() != nil {
+	if cwd == "" && t.cont.imgInfo.OciConfig != nil {
 		// if no working directory is set fallback to image config
-		cwd = t.cont.imgInfo.OciConfig().WorkingDir
+		cwd = t.cont.imgInfo.OciConfig.WorkingDir
 	}
 	t.g.SetProcessCwd(cwd)
 	t.g.SetProcessTerminal(t.cont.GetTty())
@@ -354,9 +354,9 @@ func (t *containerTranslator) configureUser() error {
 	}
 
 	userSpec := strings.Join(userParts, ":")
-	if userSpec == "" && t.cont.imgInfo.OciConfig() != nil {
+	if userSpec == "" && t.cont.imgInfo.OciConfig != nil {
 		// if no user is set fallback to image config
-		userSpec = t.cont.imgInfo.OciConfig().User
+		userSpec = t.cont.imgInfo.OciConfig.User
 	}
 
 	containerUser, err := getContainerUser(t.cont.rootfsPath(), userSpec)

--- a/pkg/kube/container_runtime.go
+++ b/pkg/kube/container_runtime.go
@@ -95,8 +95,8 @@ func (c *Container) terminate(timeout int64) error {
 
 	// otherwise give container a chance to terminate gracefully
 	var err error
-	if c.imgInfo.OciConfig() != nil && c.imgInfo.OciConfig().StopSignal != "" {
-		err = c.cli.Signal(c.id, c.imgInfo.OciConfig().StopSignal)
+	if c.imgInfo.OciConfig != nil && c.imgInfo.OciConfig.StopSignal != "" {
+		err = c.cli.Signal(c.id, c.imgInfo.OciConfig.StopSignal)
 	} else {
 		err = c.cli.Kill(c.id, false)
 	}

--- a/pkg/server/image/image.go
+++ b/pkg/server/image/image.go
@@ -102,7 +102,7 @@ func (s *SingularityRegistry) PullImage(ctx context.Context, req *k8s.PullImageR
 		glog.Warningf("Could not dump registry info: %v", err)
 	}
 	return &k8s.PullImageResponse{
-		ImageRef: info.ID(),
+		ImageRef: info.ID,
 	}, nil
 }
 
@@ -123,7 +123,7 @@ func (s *SingularityRegistry) RemoveImage(ctx context.Context, req *k8s.RemoveIm
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not remove image: %v", err)
 	}
-	if err := s.images.Remove(info.ID()); err != nil {
+	if err := s.images.Remove(info.ID); err != nil {
 		return nil, status.Errorf(codes.Internal, "could not remove image from index: %v", err)
 	}
 	if err = s.dumpInfo(); err != nil {
@@ -152,7 +152,7 @@ func (s *SingularityRegistry) ImageStatus(ctx context.Context, req *k8s.ImageSta
 
 	var uid *k8s.Int64Value
 	var username string
-	if conf := info.OciConfig(); conf != nil && conf.User != "" {
+	if info.OciConfig != nil && info.OciConfig.User != "" {
 		// If conf.User is not empty, possible options are:
 		//     * "user"
 		//     * "uid"
@@ -160,7 +160,7 @@ func (s *SingularityRegistry) ImageStatus(ctx context.Context, req *k8s.ImageSta
 		//     * "uid:gid
 		//     * "user:gid"
 		//     * "uid:group"
-		user := strings.Split(conf.User, ":")[0]
+		user := strings.Split(info.OciConfig.User, ":")[0]
 		userID, err := strconv.ParseInt(user, 10, 32)
 		if err != nil {
 			username = user
@@ -173,10 +173,10 @@ func (s *SingularityRegistry) ImageStatus(ctx context.Context, req *k8s.ImageSta
 	}
 	return &k8s.ImageStatusResponse{
 		Image: &k8s.Image{
-			Id:          info.ID(),
-			RepoTags:    info.Ref().Tags(),
-			RepoDigests: info.Ref().Digests(),
-			Size_:       info.Size(),
+			Id:          info.ID,
+			RepoTags:    info.Ref.Tags(),
+			RepoDigests: info.Ref.Digests(),
+			Size_:       info.Size,
 			Uid:         uid,
 			Username:    username,
 		},
@@ -190,10 +190,10 @@ func (s *SingularityRegistry) ListImages(ctx context.Context, req *k8s.ListImage
 	appendToResult := func(info *image.Info) {
 		if info.Matches(req.Filter) {
 			imgs = append(imgs, &k8s.Image{
-				Id:          info.ID(),
-				RepoTags:    info.Ref().Tags(),
-				RepoDigests: info.Ref().Digests(),
-				Size_:       info.Size(),
+				Id:          info.ID,
+				RepoTags:    info.Ref.Tags(),
+				RepoDigests: info.Ref.Digests(),
+				Size_:       info.Size,
 			})
 		}
 	}


### PR DESCRIPTION
Oci image config is now read upon image pulling but not dumped into `registry.json` file, so after cri restart that config will be lost. 
To simplify things image info fields are made public instead of modifying JSON marshal/unmarshal methods.