### PR TITLE
Race Detection on Go Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ uninstall:
 
 .PHONY: test
 test:
-	$(V)GO111MODULE=off GOOS=linux go test -v -coverprofile=cover.out ./...
+	$(V)GO111MODULE=off GOOS=linux go test -v -coverprofile=cover.out -race ./...
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
Add `-race` flag go `make test`. This is desirable on its own, but will also result in `mode: atomic` coverage in `cover.out`, which I think _may_ fix the Codecov reports (implied in their [Golang example](https://github.com/codecov/example-go)).