### PR TITLE
Setup port mappings as optional capabiliteis

### DIFF
--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -158,11 +158,18 @@ func (m *Manager) SetUpPod(podConfig *PodConfig) error {
 	}
 	if podConfig.PortMappings != nil {
 		for _, pm := range podConfig.PortMappings {
-			hostport := pm.HostPort
-			if hostport == 0 {
-				hostport = pm.ContainerPort
+			hostPort := pm.HostPort
+			if hostPort == 0 {
+				hostPort = pm.ContainerPort
 			}
-			args += fmt.Sprintf(";portmap=%d:%d/%s", hostport, pm.ContainerPort, strings.ToLower(pm.Protocol.String()))
+			err := podConfig.Setup.SetCapability(m.defaultNetwork.Name, "portMappings", snetwork.PortMapEntry{
+				HostPort:      int(hostPort),
+				ContainerPort: int(pm.ContainerPort),
+				Protocol:      strings.ToLower(pm.Protocol.String()),
+			})
+			if err != nil {
+				glog.Warningf("Skipping port mapping due to error: %v", err)
+			}
 		}
 	}
 	glog.V(4).Infof("Network for pod %s args: %s", podConfig.ID, args)


### PR DESCRIPTION
It tured out that port mappings do not affect services work in k8s, and since not all CNI plugins support then (e.g. OpenShift plugin), we might want to make this set up optional and do not error if plugin doesn't support port mappings.

Closes #300 