### PR TITLE
Rename 'Singularity CRI' to 'Singularity-CRI'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Singularity CRI
+# Singularity-CRI
 
 [![CircleCI](https://circleci.com/gh/sylabs/singularity-cri.svg?style=svg&circle-token=276de7aa1d82749ecf8ed6513c72399041885dec)](https://circleci.com/gh/sylabs/singularity-cri)
 [![Code Coverage](https://codecov.io/gh/sylabs/singularity-cri/branch/master/graph/badge.svg)](https://codecov.io/gh/sylabs/singularity-cri)
@@ -6,7 +6,7 @@
 
 This repository contains Singularity implementation of
 [Kubernetes CRI](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md).
-Singularity CRI consists of two separate services: runtime and image, each of which implements 
+Singularity-CRI consists of two separate services: runtime and image, each of which implements 
 K8s RuntimeService and ImageService respectively.
 
 The Singularity-CRI is currently under development and passes 71/74

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Config hold all possible parameters that are used to
-// tune Singularity CRI default behaviour.
+// tune Singularity-CRI default behaviour.
 type Config struct {
 	// ListenSocket is a unix socket to serve CRI requests on.
 	ListenSocket string `yaml:"listenSocket"`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -97,7 +97,7 @@ func main() {
 	defer cancel()
 
 	if err := startCRI(ctx, criWG, config); err != nil {
-		glog.Errorf("Could not start Singularity CRI server: %v", err)
+		glog.Errorf("Could not start Singularity-CRI server: %v", err)
 		return
 	}
 
@@ -178,10 +178,10 @@ func startCRI(ctx context.Context, wg *sync.WaitGroup, config Config) error {
 		go grpcServer.Serve(lis)
 		defer grpcServer.Stop()
 
-		glog.Infof("Singularity CRI server started on %v", lis.Addr())
+		glog.Infof("Singularity-CRI server started on %v", lis.Addr())
 		<-ctx.Done()
 
-		glog.Info("Singularity CRI service exiting...")
+		glog.Info("Singularity-CRI service exiting...")
 		if err := syRuntime.Shutdown(); err != nil {
 			glog.Errorf("Error during singularity runtime service shutdown: %v", err)
 		}


### PR DESCRIPTION
In order to be consistent across all documentation.