### PR TITLE
Remove release upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,51 +173,18 @@ jobs:
       - codecov/upload:
           file: cover_main.out
 
-  release:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: ~/
-      - run:
-          name: Install release app
-          command: make gothub-install
-      - run:
-          name: Release binaries
-          command: GITHUB_TAG=$CIRCLE_TAG make release
-
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - get_source:
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - get_source
       - unit_test:
           requires:
             - get_source
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - build_source:
           requires:
             - get_source
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
       - validation_test:
           requires:
             - build_source
             - unit_test
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-      - release:
-          context: github-release
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
-          requires:
-            - validation_test

--- a/Makefile
+++ b/Makefile
@@ -85,31 +85,3 @@ lint:
 dep:
 	$(V)go mod tidy
 	$(V)go mod vendor
-
-
-GITHUB_USER := sylabs
-GITHUB_REPO := singularity-cri
-GOTHUB := $(GOBIN)/gothub
-ARTIFACT := $(SY_CRI)
-
-# since singularity-cri uses modules we need to disable it to
-# simply install gothub without making it a dependency
-.PHONY: gothub-install
-gothub-install:
-	@echo " INSTALL" $(GOTHUB)
-	$(V)GO111MODULE=off go get github.com/itchio/gothub
-
-.PHONY: release
-release:
-	$(V) [ ! -x $(GOTHUB) ] && \
-	 echo 'Gothub is not installed, run `make gothub-install`' && \
-	 exit 1 || true
-	$(V)echo " UPLOAD" $(ARTIFACT) "TO" $(GITHUB_TAG)
-	$(V)$(GOTHUB) upload \
-        --security-token $(GITHUB_TOKEN) \
-        --user $(GITHUB_USER) \
-        --repo $(GITHUB_REPO) \
-        --tag $(GITHUB_TAG) \
-        --name "Singularity-CRI" \
-        --file $(SY_CRI) \
-        --replace


### PR DESCRIPTION
As discussed with @jscook2345, a combination of platforms and build tags, combined with CGO makes it unreasonable for us to cover all of that in CI (at least now). We decided to stick with installing from source code.

Related to #310 