### PR TITLE
Capture coverage of package being tested only in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ uninstall:
 
 .PHONY: test
 test:
-	$(V)GOOS=linux go test -mod vendor -v -coverpkg=./... -coverprofile=cover.out -race ./...
+	$(V)GOOS=linux go test -mod vendor -v -coverprofile=cover.out -race ./...
 
 $(SY_CRI_TEST):
 	@echo " GO" $@


### PR DESCRIPTION
After some thoughts it doesn't seem reasonable to capture coverage of all packages in unit tests. This makes sense with validation tests in circleCi though, but with unit tests produced coverage seems really confusing.