### PR TITLE
Drain master end of pty to prevent stderr from hanging

### DIFF
--- a/pkg/singularity/runtime/client_oci.go
+++ b/pkg/singularity/runtime/client_oci.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -122,6 +123,7 @@ func (c *CLIClient) Create(id, bundle string, stdin, tty bool, flags ...string) 
 			glog.V(5).Info("Starting stream copying from master to stderr")
 			_, err := io.Copy(os.Stderr, syio.NewContextReader(ctx, master))
 			glog.V(5).Infof("Stream copying returned: %v", err)
+			go io.Copy(ioutil.Discard, master)
 		}()
 		stdinWrite = master
 

--- a/pkg/singularity/runtime/client_oci.go
+++ b/pkg/singularity/runtime/client_oci.go
@@ -123,6 +123,8 @@ func (c *CLIClient) Create(id, bundle string, stdin, tty bool, flags ...string) 
 			glog.V(5).Info("Starting stream copying from master to stderr")
 			_, err := io.Copy(os.Stderr, syio.NewContextReader(ctx, master))
 			glog.V(5).Infof("Stream copying returned: %v", err)
+			// we need to drain master to prevent buffer overflow,
+			// see https://github.com/sylabs/singularity-cri/pull/348
 			go io.Copy(ioutil.Discard, master)
 		}()
 		stdinWrite = master


### PR DESCRIPTION
Turned out if master end of pty is not drained, after some period of time no new stderr entries appear in container's logs. This may happen due to buffer overflow, and this PR fixes it by simply draining master end.

Fixes #347 